### PR TITLE
fix Chatkit wrong API version on request to get cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ To get started, you first need to create your `config.json` file. Below is an ex
   "messagesToLoad": 5,
   "chatkit": {
     "instanceLocator": "MY_INSTANCE_LOCATER_FROM_PUSHER_DASH",
-    "key": "MY_VERY_SECRET_KEY_FROM_PUSHER_DASH"
+    "key": "MY_VERY_SECRET_KEY_FROM_PUSHER_DASH",
+    "apiVersion": "v2"
   },
   "push": {
     "endpoint": "https://api.myapplication.com/v1/chatkit/push",

--- a/chatkithelper.js
+++ b/chatkithelper.js
@@ -3,7 +3,7 @@ import Rx from "rxjs/Rx";
 const request = require('request');
 
 export class ChatkitHelper {
-    constructor(chatkitInstance, pushHelperInstance) {
+    constructor(chatkitInstance, pushHelperInstance, apiVersion) {
         /**
          * @type Chatkit
          */
@@ -13,6 +13,12 @@ export class ChatkitHelper {
          * @type PushHelper
          */
         this.pushHelperInstance = pushHelperInstance;
+
+        /**
+         * API version (.e.g "v2")
+         * @type String
+         */
+        this.apiVersion = apiVersion;
     }
 
     /**
@@ -55,8 +61,8 @@ export class ChatkitHelper {
      */
     getUserCursors(userId) {
         return Rx.Observable.fromPromise(new Promise((resolve, reject) => {
-            const [_, apiVersion, location, instanceId] = this.chatkitInstance.instanceLocator.match(/^(v\d*):([a-z0-9]*):([a-f0-9\-]*)$/);
-            request('https://' + location + '.pusherplatform.io/services/chatkit_cursors/' + apiVersion + '/' + instanceId + '/cursors/0/users/' + userId, {
+            const [_, __, location, instanceId] = this.chatkitInstance.instanceLocator.match(/^(v\d*):([a-z0-9]*):([a-f0-9\-]*)$/);
+            request('https://' + location + '.pusherplatform.io/services/chatkit_cursors/' + this.apiVersion + '/' + instanceId + '/cursors/0/users/' + userId, {
                 headers: {
                     'Authorization': 'Bearer ' + this.chatkitInstance.getServerToken()
                 }


### PR DESCRIPTION
I was getting an error because of the API version.
It's possible to set the API version in the `MY_INSTANCE_LOCATER_FROM_PUSHER_DASH` (e.g.` v1:us1:your-instance-id`).
But I thought this would be more explicit, and since in my Chatkit Pusher dashboard it says `v1:us1:my-instance-id`.